### PR TITLE
Changing some of the procedures of name-clusters

### DIFF
--- a/name-clusters/metadata.json
+++ b/name-clusters/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "Name clusters",
+  "kind": "script",
+  "description": "Gives a name to clusters using important field names",
+  "source_code": "script.whizzml",
+  "inputs":[
+    {
+      "name": "cluster-id",
+      "type": "cluster-id",
+      "description": "The cluster to update"
+    },
+    {
+      "name": "number-of-terms",
+      "type": "number",
+      "default": 2,
+      "description": "Number of terms to use in clusters name"
+    },
+    {
+      "name": "separator",
+      "type": "string",
+      "default": ",",
+      "description": "Separator to join terms to form clusters name"
+    }],
+  "outputs":[
+    {
+      "name": "result",
+      "type": "list",
+      "description": "List of cluster names"
+    }]
+}

--- a/name-clusters/script.whizzml
+++ b/name-clusters/script.whizzml
@@ -1,0 +1,100 @@
+;; cluster-model-importances
+;;
+;; Returns importances from the model associated to a cluster
+;; Creates the model if it doesn't exist
+;;
+;; Inputs:
+;;   cluster: (map) Map with cluster (centroid) attributes
+;;   cl-models: (map) Cluster IDs and their corresponding models
+;;
+;; Output: (list) List of field names and importances
+(define (cluster-model-importances cluster cl-models)
+  (let (centroid-id (cluster "id")
+        model-id (cl-models centroid-id false)
+        model-id (if model-id
+                   (join ["model/" model-id])
+                   (create "model" {"cluster" cluster-id
+                                    "centroid" centroid-id}))
+        model (fetch model-id)
+        fields (model ["model" "fields"])
+        importances-ids (model ["model" "importance"]))
+    
+    (map (lambda (n) [(fields [(head n) "name"]) (tail n)])
+         importances-ids)))
+    
+    
+
+
+
+
+;; cluster-name
+;;
+;; Creates cluster name  using the most important field names of its
+;; correspondent model
+;;
+;; Inputs:
+;;   cluster: (map) Map with cluster (centroid)  attributes
+;;   clusters: (map) Named cluster (centroid) IDs along their new names
+;;   cl_models: (map) Clusters IDs and their corresponding models         
+;;   number-of-terms: (number) Number of terms to use in cluster name
+;;   separator: (string) Separator to join terms to form cluster names
+;;
+;; Outputs: (string) Cluster name
+;;
+(define (cluster-name cluster clusters cl-models  number-of-terms separator)
+  (let (fields (cluster-model-importances cluster cl-models)
+        n (- number-of-terms 1)
+	;; List of already named clusters to avoid repeating names
+        seen (map (lambda (c) (c "name")) (values clusters)))
+    (loop (cs (map head (tail fields)))
+     (if (empty? cs)
+        (head (head fields))
+        (let (c (join separator (cons (head (head fields)) (take n cs))))
+          (if (member? c seen)
+	    (recur (tail cs))
+	    c))))))
+
+
+;; rename-clusters
+;;
+;; Retrieves a cluster and renames it using the most important
+;; field names of its correspondent model
+;;
+;; Inputs:
+;;   cl-id: (resource-id) ID of the cluster model
+;;   number-of-terms: (number) Number of terms to use in cluster name
+;;   separator: (string) Separator to join terms to form cluster names
+;;
+;; Output: (list) List of cluster names
+;;
+(define (rename-clusters cl-id number-of-terms separator)
+  (let (cl (fetch cl-id)
+        models? (cl "model_clusters")
+        cl-models (cl "cluster_models")
+        clusters (when models?
+                   (reduce (lambda (ns cluster)
+                             (assoc ns
+                                    (cluster "id")
+                                    {"name" (cluster-name cluster
+                                                          ns
+                                                          cl-models
+                                                          number-of-terms
+                                                          separator)}))
+                       {}
+                       (cl ["clusters" "clusters"]))))
+    (if models?
+      (prog (try (update cl-id {"clusters" clusters})
+                 (catch e
+                   (log-error "Error updating clusters: " e)
+                   (raise e)))
+            (values clusters))
+      (log-error "Error. Cluster doesn't have any model."))))
+
+;; result
+;;
+;; Updates clusters name using the importance of their fields in each
+;; cluster model
+;; Output: (list) List of cluster names
+(define result (rename-clusters cluster-id
+			        number-of-terms
+			        separator))

--- a/name-clusters/script.whizzml
+++ b/name-clusters/script.whizzml
@@ -1,58 +1,74 @@
-;; cluster-model-importances
+;; model-importances
 ;;
-;; Returns importances from the model associated to a cluster
-;; Creates the model if it doesn't exist
+;; Returns importances from the model
 ;;
 ;; Inputs:
-;;   cluster: (map) Map with cluster (centroid) attributes
-;;   cl-models: (map) Cluster IDs and their corresponding models
+;;   model-id: (map) Corresponding model ID
 ;;
-;; Output: (list) List of field names and importances
-(define (cluster-model-importances cluster cl-models)
-  (let (centroid-id (cluster "id")
-        model-id (cl-models centroid-id false)
-        model-id (if model-id
-                   (join ["model/" model-id])
-                   (create "model" {"cluster" cluster-id
-                                    "centroid" centroid-id}))
-        model (fetch model-id)
-        fields (model ["model" "fields"])
+;; Output: (list) String representing the field = value name
+(define (model-importances model-id)
+  (let (model (fetch model-id)
         importances-ids (model ["model" "importance"]))
-    
-    (map (lambda (n) [(fields [(head n) "name"]) (tail n)])
+    (map (lambda (n) (head n))
          importances-ids)))
-    
-    
 
 
+;; generate-models
+;;
+;; Returns a list of the model IDs for the clusters when finished
+;;
+;; Inputs:
+;;   cluster-id: (string) Cluster ID
+;;   centroid-ids: (list) List of centroid IDs
+;;
+;; Output: (list) String representing the field = value name
+(define (generate-models cluster-id centroid-ids)
+  (let (cluster (fetch cluster-id)
+        models (cluster "cluster_models" {})
+        model-ids (for (centroid-id centroid-ids)
+                    (if (models centroid-id false)
+                        (str "model/" (models centroid-id))
+                        (create "model" {"cluster" cluster-id
+                                         "centroid" centroid-id}))))
+    (wait* model-ids)))
 
 
 ;; cluster-name
 ;;
 ;; Creates cluster name  using the most important field names of its
-;; correspondent model
+;; correspondent model and the centroid values
 ;;
 ;; Inputs:
-;;   cluster: (map) Map with cluster (centroid)  attributes
-;;   clusters: (map) Named cluster (centroid) IDs along their new names
-;;   cl_models: (map) Clusters IDs and their corresponding models         
+;;   clusters: (map) Structure of changes to set the names
+;;   centroid: (map) Centroid info
+;;   fields: (map) Cluster fields
+;;   model-id: (map) Model ID
 ;;   number-of-terms: (number) Number of terms to use in cluster name
 ;;   separator: (string) Separator to join terms to form cluster names
 ;;
 ;; Outputs: (string) Cluster name
 ;;
-(define (cluster-name cluster clusters cl-models  number-of-terms separator)
-  (let (fields (cluster-model-importances cluster cl-models)
+(define (cluster-name clusters
+                      centroid
+                      fields
+                      model-id
+                      number-of-terms
+                      separator)
+  (let (importances-ids (model-importances model-id)
+        name-strs (map (lambda (x) (str (fields [x "name"] "")
+                                        " = "
+                                        (centroid ["center" x])))
+                       importances-ids)
         n (- number-of-terms 1)
-	;; List of already named clusters to avoid repeating names
+    ;; List of already named clusters to avoid repeating names
         seen (map (lambda (c) (c "name")) (values clusters)))
-    (loop (cs (map head (tail fields)))
+    (loop (cs (tail name-strs))
      (if (empty? cs)
-        (head (head fields))
-        (let (c (join separator (cons (head (head fields)) (take n cs))))
+        (head name-strs)
+        (let (c (join separator (cons (head name-strs) (take n cs))))
           (if (member? c seen)
-	    (recur (tail cs))
-	    c))))))
+        (recur (tail cs))
+        c))))))
 
 
 ;; rename-clusters
@@ -69,19 +85,23 @@
 ;;
 (define (rename-clusters cl-id number-of-terms separator)
   (let (cl (fetch cl-id)
+        fields (cl ["clusters" "fields"])
         models? (cl "model_clusters")
-        cl-models (cl "cluster_models")
+        centroids (cl ["clusters" "clusters"])
+        centroid-ids (map (lambda (c) (c "id")) centroids)
+        ;; generate models for all centroids
+        model-ids (when models?
+                    (generate-models cl-id centroid-ids))
         clusters (when models?
-                   (reduce (lambda (ns cluster)
-                             (assoc ns
-                                    (cluster "id")
-                                    {"name" (cluster-name cluster
-                                                          ns
-                                                          cl-models
-                                                          number-of-terms
-                                                          separator)}))
-                       {}
-                       (cl ["clusters" "clusters"]))))
+                   (iterate (ns {} centroid centroids model-id model-ids)
+                     (assoc ns
+                            (centroid "id")
+                            {"name" (cluster-name ns
+                                                  centroid
+                                                  fields
+                                                  model-id
+                                                  number-of-terms
+                                                  separator)}))))
     (if models?
       (prog (try (update cl-id {"clusters" clusters})
                  (catch e
@@ -90,11 +110,12 @@
             (values clusters))
       (log-error "Error. Cluster doesn't have any model."))))
 
+
 ;; result
 ;;
 ;; Updates clusters name using the importance of their fields in each
 ;; cluster model
 ;; Output: (list) List of cluster names
 (define result (rename-clusters cluster-id
-			        number-of-terms
-			        separator))
+                                number-of-terms
+                                separator))


### PR DESCRIPTION
Avoiding some problems when updating clusters with more than 2 centroids. Also, changing the name to include the value for the important fields in the centroid.